### PR TITLE
Fixing build options for legacy-mono and *-il2cpp

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Import local overrides if they exist (should be git-ignored) -->
+  <Import Project="Directory.Build.props.user" Condition="Exists('Directory.Build.props.user')" />
+
   <PropertyGroup>
-    <BepInExDir>C:\Users\rai\AppData\Roaming\raicuparta\rai-pal\data\mod-loaders\bepinex</BepInExDir>
+    <!-- Default/fallback value if not overridden -->
+    <BepInExDir Condition="'$(BepInExDir)' == ''">C:\Users\rai\AppData\Roaming\raicuparta\rai-pal\data\mod-loaders\bepinex</BepInExDir>
   </PropertyGroup>
 
   <!--  Il2Cpp  -->

--- a/Directory.Build.props.user.template
+++ b/Directory.Build.props.user.template
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <BepInExDir>CHANGE_PATH_TO_WHAT_SUITS_YOU_BEST. e.g., .\bin</BepInExDir>
+    </PropertyGroup>
+</Project>

--- a/Uuvr/ThingDisabler.cs
+++ b/Uuvr/ThingDisabler.cs
@@ -55,7 +55,11 @@ public class ThingDisabler : UuvrBehaviour
             .Where(name => !string.IsNullOrEmpty(name))
             .SelectMany(name =>
             {
+#if CPP
+                var type = Il2CppSystem.Type.GetType(name);
+#else
                 var type = Type.GetType(name);
+#endif
                 return FindObjectsOfType(type);
             });
     }

--- a/Uuvr/TypeExtensions.cs
+++ b/Uuvr/TypeExtensions.cs
@@ -16,6 +16,26 @@ public static class TypeExtensions
                type.BaseType?.BaseType?.GetMember(name, Flags).FirstOrDefault();
     }
 
+#if LEGACY && MONO
+    /// <summary>
+    /// Act as .NET 9.0 method which doesn't exist in .NET 2.0
+    /// </summary>
+    /// <see url="https://learn.microsoft.com/en-us/dotnet/api/system.reflection.propertyinfo.getvalue?view=net-9.0#system-reflection-propertyinfo-getvalue(system-object)" />
+    public static object? GetValue(this PropertyInfo property, object? obj)
+    {
+        return property.GetValue(obj, null);
+    }
+    
+    /// <summary>
+    /// Act as .NET 9.0 method which doesn't exist in .NET 2.0
+    /// </summary>
+    /// <see url="https://learn.microsoft.com/en-us/dotnet/api/system.reflection.propertyinfo.setvalue?view=net-9.0#system-reflection-propertyinfo-setvalue(system-object-system-object)" />
+    public static void SetValue(this PropertyInfo property, object? obj, object? value)
+    {
+        property.SetValue(obj, value, null);
+    }
+#endif
+    
     public static T? GetValue<T>(this object obj, string name)
     {
         return obj.GetType().GetAnyMember(name) switch


### PR DESCRIPTION
Hi Raicuparta.

I tried to build UUVR from main branch but failed locally.
(Everyone can nag, therefore I tried to solve these build time issues instead. 😉)

This PR includes:
1. fixing issues related to _ThingDisabler.cs_
    * wrap missing _PropertyInfo_ functions for legacy-mono .net version
    * fix Invalid cast for _Il2CppSystem.Type_ on IL2CPP builds
2. add the capability to set output directory to a custom one when needed (via .gitignored _Directory.Build.props.user_ file.)

> [!NOTE]
> Building the UUVR mods from within Rider works and I get proper DLLs created. I also tested my changes with legacy-mono and it works perfectly. (My tested game Yooka-Laylee starts and has stereoscopic VR)

Thank you for your work
JaXt0r